### PR TITLE
fix(i18n): preserve division-by-zero literal in Spanish calculator step

### DIFF
--- a/curriculum/challenges/espanol/blocks/workshop-calculator/66cc1deb1f04647f2aabee2b.md
+++ b/curriculum/challenges/espanol/blocks/workshop-calculator/66cc1deb1f04647f2aabee2b.md
@@ -13,11 +13,11 @@ La división por cero no es una operación válida en matemáticas.
 
 Para tener en cuenta este caso extremo, debes actualizar tu función `calculateQuotient` para comprobar si `num2` es cero. 
 
-Si `num2` es cero, la función debe devolver la cadena `"Error: División por cero"`. De lo contrario, debe devolver el resultado de dividir `num1` por `num2`.
+Si `num2` es cero, la función debe devolver la cadena `"Error: Division by zero"`. De lo contrario, debe devolver el resultado de dividir `num1` por `num2`.
 
 # --hints--
 
-Tu función `calculateQuotient` debe devolver la cadena `"Error: División por cero"` si `num2` es cero. 
+Tu función `calculateQuotient` debe devolver la cadena `"Error: Division by zero"` si `num2` es cero.
 
 ```js
 assert.strictEqual(calculateQuotient(10, 0), 'Error: Division by zero');


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch.
- [x] I have tested these changes locally.

Closes freeCodeCamp/freeCodeCamp#67626

This updates the Spanish workshop calculator step 15 copy so the division-by-zero string literal shown to campers matches the existing tests:

- keeps the surrounding Spanish instructions/hint text
- restores the required literal to `"Error: Division by zero"` in both the description and hint

Local verification:

- `python3 - <<'PY' ...` targeted check that the Spanish file has two visible `"Error: Division by zero"` literals, no visible `"Error: División por cero"` literals, and still has the two matching test assertions
- `git diff --check`
